### PR TITLE
feat: Make application port configurable via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the entire application source code into the container
 COPY . /app
 
+# Set an argument for the port with a default value
+ARG PORT=5201
+# Set the environment variable for the port
+ENV PORT=${PORT}
+
 # Expose the port the app will run on
-EXPOSE 8000
+EXPOSE ${PORT}
 
 # Command to run the application
 # The host 0.0.0.0 makes it accessible from outside the container
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${PORT}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,14 @@ version: '3.8'
 
 services:
   backend:
-    build: .
+    build:
+      context: .
+      args:
+        - PORT=${PORT:-5201}
     ports:
-      - "8000:8000"
+      - "${PORT:-5201}:${PORT:-5201}"
     environment:
+      - PORT=${PORT:-5201}
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     depends_on:
       - db


### PR DESCRIPTION
This commit makes the application port configurable through a `PORT` environment variable.

- Modified `docker-compose.yml` to use the `PORT` variable for port mapping and as an environment variable for the backend service.
- Updated the `Dockerfile` to accept a `PORT` build argument and use it to expose the port and run the uvicorn server.
- Created a `.env` file to set the default port to `5201`.

This change allows users to easily change the application's port without modifying the source code, for example by running `PORT=8080 docker-compose up`. If the `PORT` variable is not set, it defaults to `5201`.