### PR TITLE
Fix Docker database connection and Python path issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the entire application source code into the container
 COPY . /app
 
+# Set the project root as the PYTHONPATH
+ENV PYTHONPATH /app
+
 # Set an argument for the port with a default value
 ARG PORT=5201
 # Set the environment variable for the port

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -42,7 +42,7 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    url = "sqlite:///./joulejournal.db"
+    url = os.getenv("DATABASE_URL", "sqlite:///./joulejournal.db")
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -62,7 +62,7 @@ def run_migrations_online() -> None:
 
     """
     # Get the database URL from the environment variable
-    db_url = "sqlite:///./joulejournal.db"
+    db_url = os.getenv("DATABASE_URL", "sqlite:///./joulejournal.db")
 
     # For SQLite, we need to add a special connect_args argument
     connect_args = {}


### PR DESCRIPTION
This commit addresses two issues when running the application with Docker:

1. Alembic was configured to use a hardcoded SQLite database URL, causing migrations to fail against the PostgreSQL database. This has been corrected by updating `alembic/env.py` to use the `DATABASE_URL` environment variable.

2. The `seed_db.py` script was failing with a `ModuleNotFoundError` because the Python path was not correctly configured in the Docker container. This has been resolved by adding `ENV PYTHONPATH /app` to the `Dockerfile`.