### PR TITLE
Make database seeding script idempotent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the entire application source code into the container
 COPY . /app
 
+# Set the project root as the PYTHONPATH
+ENV PYTHONPATH /app
+
 # Set an argument for the port with a default value
 ARG PORT=5201
 # Set the environment variable for the port

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -42,7 +42,7 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    url = "sqlite:///./joulejournal.db"
+    url = os.getenv("DATABASE_URL", "sqlite:///./joulejournal.db")
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -62,7 +62,7 @@ def run_migrations_online() -> None:
 
     """
     # Get the database URL from the environment variable
-    db_url = "sqlite:///./joulejournal.db"
+    db_url = os.getenv("DATABASE_URL", "sqlite:///./joulejournal.db")
 
     # For SQLite, we need to add a special connect_args argument
     connect_args = {}

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -7,20 +7,26 @@ from app.schemas.tariff import TariffCreate
 from app.schemas.metrics import MonthlyMetricCreate
 from datetime import date
 
+from app.models import models
+
 def seed_db():
     db: Session = SessionLocal()
 
     # Seed Investments
-    investment_df = pd.read_csv('scripts/data/investment.csv', parse_dates=['install_date'])
-    investment_data = investment_df.iloc[0].to_dict()
-    investment = InvestmentCreate(
-        description=investment_data['description'],
-        installation_date=investment_data['install_date'],
-        total_cost_eur=investment_data['total_investment_cost'],
-        total_power_wp=investment_data['total_wp'],
-        estimated_annual_production_kwh=investment_data['estimated_annual_production_kwh']
-    )
-    crud_investments.create_investment(db, investment=investment)
+    if db.query(models.Investment).count() == 0:
+        investment_df = pd.read_csv('scripts/data/investment.csv', parse_dates=['install_date'])
+        investment_data = investment_df.iloc[0].to_dict()
+        investment = InvestmentCreate(
+            description=investment_data['description'],
+            installation_date=investment_data['install_date'],
+            total_cost_eur=investment_data['total_investment_cost'],
+            total_power_wp=investment_data['total_wp'],
+            estimated_annual_production_kwh=investment_data['estimated_annual_production_kwh']
+        )
+        crud_investments.create_investment(db, investment=investment)
+        print("✅ Investment seeded.")
+    else:
+        print("ℹ️ Investments already exist, skipping.")
 
     # Seed Tariffs
     tariffs_df = pd.read_csv('scripts/data/tariffs.csv', parse_dates=['start_date', 'end_date'])
@@ -35,10 +41,16 @@ def seed_db():
             purchase_low_eur_kwh=row_data['purchase_rate_low'],
             purchase_high_eur_kwh=row_data['purchase_rate_high'],
             sale_eur_kwh=row_data['feed_in_rate'],
-            vat_percentage=row_data['vat_percentage'] / 100, # Convert percentage to float
+            vat_percentage=row_data['vat_percentage'] / 100,
             fixed_roi_rate_eur_kwh=row_data['fixed_roi_rate']
         )
-        crud_tariffs.create_tariff(db, tariff=tariff)
+
+        exists = db.query(models.Tariff).filter(models.Tariff.start_date == tariff.start_date).first()
+        if not exists:
+            crud_tariffs.create_tariff(db, tariff=tariff)
+            print(f"✅ Tariff for {tariff.start_date.date()} seeded.")
+        else:
+            print(f"ℹ️ Tariff for {tariff.start_date.date()} already exists, skipping.")
 
     # Seed Metrics
     metrics_df = pd.read_csv('scripts/data/metrics.csv', parse_dates=['period'])
@@ -55,10 +67,16 @@ def seed_db():
             battery_discharge_kwh=row['battery_discharge_kwh'],
             monthly_prepayment_eur=row['prepayment_amount']
         )
-        crud_metrics.create_monthly_metric(db, metric=metric)
+
+        exists = db.query(models.MonthlyMetric).filter(models.MonthlyMetric.period_start == metric.period_start).first()
+        if not exists:
+            crud_metrics.create_monthly_metric(db, metric=metric)
+            print(f"✅ Metric for {metric.period_start.date()} seeded.")
+        else:
+            print(f"ℹ️ Metric for {metric.period_start.date()} already exists, skipping.")
 
     db.close()
-    print("Database has been seeded successfully!")
+    print("\nDatabase seeding check complete! 🌱")
 
 if __name__ == "__main__":
     seed_db()


### PR DESCRIPTION
The `seed_db.py` script is executed every time the backend container starts. Since the database is persisted in a volume, this caused `IntegrityError` on subsequent runs as the script attempted to insert data that already existed.

This commit makes the seeding script idempotent by adding checks to verify if data already exists before attempting to insert it. This ensures the script can be run multiple times without causing errors.