### PR TITLE
Fix Dockerfile CMD to correctly start uvicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ EXPOSE ${PORT}
 
 # Command to run the application
 # The host 0.0.0.0 makes it accessible from outside the container
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${PORT}"]
+# Use shell form to correctly expand the PORT variable
+CMD exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT}


### PR DESCRIPTION
The CMD instruction in the Dockerfile was using the exec form, which does not perform shell expansion of environment variables. This caused the ${PORT} variable to be passed as a literal string to uvicorn, instead of its value.

This change switches the CMD instruction to the shell form, ensuring that the ${PORT} variable is correctly substituted. The `exec` keyword is used to make the uvicorn process the main process (PID 1) in the container, which is a best practice for signal handling.

This change fixes a critical startup issue that likely prevented the web application from being accessible.