### PR TITLE
Fix server startup failure due to missing PORT variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ EXPOSE ${PORT}
 
 # Command to run the application
 # The host 0.0.0.0 makes it accessible from outside the container
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${PORT}"]
+# Use shell form to correctly expand the PORT variable
+CMD exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,14 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     command: >
       bash -c "
-        alembic upgrade head &&
-        python scripts/seed_db.py &&
-        uvicorn app.main:app --host 0.0.0.0 --port ${PORT}
+        set -e
+        set -x
+        echo '--- Running database migrations ---'
+        alembic upgrade head
+        echo '--- Seeding database ---'
+        python scripts/seed_db.py
+        echo '--- Starting web server ---'
+        uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-5201}
       "
     depends_on:
       db:


### PR DESCRIPTION
The application was failing to start because the `uvicorn` command was being called with a `--port` option but no value, as the `${PORT}` environment variable was not being correctly expanded.

This fix addresses the issue by using shell parameter expansion to provide a default value of `5201` for the port. The command is changed to `... --port ${PORT:-5201}`. This ensures that `uvicorn` always receives a valid port number, even if the `PORT` environment variable is not set in the execution environment (e.g., Portainer).

This commit also retains the verbose logging added previously to aid in future debugging.