### PR TITLE
Fix ImportError in analysis schema and add missing dependency

### DIFF
--- a/app/schemas/analysis.py
+++ b/app/schemas/analysis.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 from typing import Dict, Any
-from .metrics import MonthlyMetricInDB
+from .metrics import MonthlyMetric
 
 class EnergyFlowResult(BaseModel):
     self_consumption_kwh: float
@@ -21,7 +21,7 @@ class MonthlyAnalysisResult(BaseModel):
     A comprehensive schema for a single month's analysis, combining the
     raw metric data with calculated energy and financial results.
     """
-    metric: MonthlyMetricInDB
+    metric: MonthlyMetric
     energy_flow: EnergyFlowResult
     financials: FinancialResult
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ python-dotenv
 # Security & Authentication
 passlib[bcrypt]
 python-jose[cryptography]
+python-multipart
 
 # Templating
 Jinja2


### PR DESCRIPTION
- In `app/schemas/analysis.py`, changed the import from `MonthlyMetricInDB` to `MonthlyMetric` to fix an `ImportError` on startup. `MonthlyMetric` is the correct schema to use for client-facing data.
- Added `python-multipart` to `requirements.txt`. This dependency is required by FastAPI for form data and was causing a `RuntimeError` after the initial import error was fixed.