### PR TITLE
Fix(auth): Pass admin credentials to backend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "${PORT:-5201}:${PORT:-5201}"
     environment:
       - PORT=${PORT:-5201}
+      - ADMIN_USER=${ADMIN_USER}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     command: >
       bash -lc "


### PR DESCRIPTION
The ADMIN_USER and ADMIN_PASSWORD environment variables were not being passed to the backend service in the docker-compose.yml file. This caused the application to fall back to the default credentials, preventing the user from logging in with their configured credentials.

This commit adds the ADMIN_USER and ADMIN_PASSWORD environment variables to the backend service's environment configuration in docker-compose.yml, ensuring that the user-defined credentials are correctly used by the application.