### PR TITLE
feat: Implement robust, configurable logging

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -123,17 +123,17 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARNING
+level = ERROR
 handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = WARNING
+level = ERROR
 handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = INFO
+level = ERROR
 handlers =
 qualname = alembic
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,7 +18,11 @@ class Settings:
         SECRET_KEY: The secret key for signing JWTs.
         ALGORITHM: The algorithm used for JWT encoding.
         ACCESS_TOKEN_EXPIRE_MINUTES: The expiry time for access tokens in minutes.
+        LOG_LEVEL: The logging level for the application.
     """
+    # Application settings
+    LOG_LEVEL: str = os.getenv("LOG_LEVEL", "ERROR")
+
     # Admin credentials
     ADMIN_USER: str = os.getenv("ADMIN_USER", "admin")
     ADMIN_PASSWORD: str = os.getenv("ADMIN_PASSWORD", "secret")

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -1,5 +1,50 @@
-import logging
+import logging.config
+import os
+from app.core.config import settings
 from pythonjsonlogger import jsonlogger
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": "app.core.logging_config.CustomJsonFormatter",
+        },
+    },
+    "handlers": {
+        "default": {
+            "level": settings.LOG_LEVEL,
+            "formatter": "json",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "": {  # root logger
+            "level": settings.LOG_LEVEL,
+            "handlers": ["default"],
+            "propagate": False,
+        },
+        "uvicorn.error": {
+            "level": settings.LOG_LEVEL,
+            "handlers": ["default"],
+            "propagate": False,
+        },
+        "uvicorn.access": {
+            "level": settings.LOG_LEVEL,
+            "handlers": ["default"],
+            "propagate": False,
+        },
+        "joulejournal": {
+            "level": settings.LOG_LEVEL,
+            "handlers": ["default"],
+            "propagate": False,
+        },
+    },
+}
+
+def setup_logging():
+    logging.config.dictConfig(LOGGING_CONFIG)
 
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
@@ -10,16 +55,3 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             log_record['level'] = log_record['level'].upper()
         else:
             log_record['level'] = record.levelname
-
-def setup_logging():
-    logger = logging.getLogger("joulejournal")
-    logger.setLevel(logging.INFO)
-    logHandler = logging.StreamHandler()
-    formatter = CustomJsonFormatter('%(timestamp)s %(level)s %(name)s %(message)s')
-    logHandler.setFormatter(formatter)
-    logger.addHandler(logHandler)
-
-    uvicorn_logger = logging.getLogger("uvicorn")
-    uvicorn_logger.handlers = [logHandler]
-    uvicorn_access_logger = logging.getLogger("uvicorn.access")
-    uvicorn_access_logger.handlers = [logHandler]

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from app.core.logging_config import setup_logging
 
+setup_logging()
+
 from app.api.endpoints import (
     analysis,
     metrics,
@@ -21,11 +23,6 @@ app = FastAPI(
     description="Een webapplicatie voor het monitoren, analyseren en rapporteren van energieverbruik.",
     version="1.0.0"
 )
-
-# Call setup_logging on startup
-@app.on_event("startup")
-async def startup_event():
-    setup_logging()
 
 # Middleware to log requests
 @app.middleware("http")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ADMIN_USER=${ADMIN_USER}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - LOG_LEVEL=${LOG_LEVEL:-ERROR}
     command: >
       bash -lc "
         set -euxo pipefail

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,6 @@ Jinja2
 
 # Logging
 python-json-logger
+
+# Testing
+pytest


### PR DESCRIPTION
This commit introduces a robust logging configuration for the application.

Key changes:
- Implemented a dictionary-based logging configuration in `app/core/logging_config.py`.
- The log level is now configurable via the `LOG_LEVEL` environment variable, defaulting to `ERROR`.
- The logging configuration is applied at application startup in `app/main.py`.
- The `docker-compose.yml` file has been updated to pass the `LOG_LEVEL` environment variable to the `backend` service.
- The `alembic.ini` file has been updated to set the log level for Alembic to `ERROR`, reducing verbosity during migrations.
- Added `pytest` to `requirements.txt` to support running tests.