### PR TITLE
Improve Dockerfile for robust builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ FROM python:3.12-slim
 # Set the working directory inside the container
 WORKDIR /app
 
-# Install Poetry
-RUN pip install poetry
+# Install Poetry (pin to lockfile version) and upgrade pip
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir poetry==2.1.3
 
 # Install system dependencies required for building Python packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -18,11 +19,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy the dependency files
 COPY pyproject.toml poetry.lock ./
 
+# Configure Poetry to install into the system environment (no venv in container)
+ENV POETRY_VIRTUALENVS_CREATE=false
+
 # Install the Python dependencies using Poetry
 # --no-interaction: Do not ask any interactive question
 # --no-root: Do not install the root package (the project itself)
-# --no-dev: Do not install dev dependencies
-RUN poetry install -vvv --no-interaction --no-root --no-dev
+# --without dev: Do not install dev dependencies (Poetry 2.x)
+RUN poetry install --no-interaction --no-root --without dev
 
 # Copy the entire application source code into the container
 COPY . /app
@@ -38,7 +42,7 @@ ENV PORT=${PORT}
 # Expose the port the app will run on
 EXPOSE ${PORT}
 
-# Command to run the application using poetry's virtual env
+# Command to run the application
 # The host 0.0.0.0 makes it accessible from outside the container
 # Use shell form to correctly expand the PORT variable
-CMD exec poetry run uvicorn app.main:app --host 0.0.0.0 --port ${PORT}
+CMD exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT}


### PR DESCRIPTION
This commit replaces the existing Dockerfile with a more robust, idiomatic version for building a Python application with Poetry.

Key improvements include:
- Pinning the version of Poetry for reproducible builds.
- Disabling the creation of virtual environments within the container, which is a best practice.
- Simplifying the CMD instruction by removing the now-unnecessary 'poetry run'.
- Ensuring necessary system build dependencies are installed.

This resolves the 'compose build operation failed' error.