### PR TITLE
Fix: Correct battery ROI by accounting for solar charging

### DIFF
--- a/app/services/roi_calculations.py
+++ b/app/services/roi_calculations.py
@@ -76,9 +76,25 @@ def calculate_battery_roi(db: Session, battery_id: int) -> ROIStatus:
     cumulative_savings = Decimal(0.0)
 
     for journal in journals:
-        # Simplified arbitrage calculation
+        # More accurate arbitrage calculation that accounts for charging from solar
+        battery_charge_kwh = Decimal(journal.battery_charge_kwh or 0)
+        solar_production_kwh = Decimal(journal.solar_production_kwh or 0)
+        grid_feed_in_low_kwh = Decimal(journal.grid_feed_in_low_kwh or 0)
+        grid_feed_in_high_kwh = Decimal(journal.grid_feed_in_high_kwh or 0)
+
+        # Self-consumption is the solar energy produced that was not exported to the grid
+        total_grid_feed_in_kwh = grid_feed_in_low_kwh + grid_feed_in_high_kwh
+        self_consumption_kwh = solar_production_kwh - total_grid_feed_in_kwh
+
+        # Prioritize charging from free solar energy
+        charge_from_solar_kwh = min(battery_charge_kwh, self_consumption_kwh)
+        charge_from_grid_kwh = battery_charge_kwh - charge_from_solar_kwh
+
+        # Cost is only incurred for charging from the grid
+        charge_cost = charge_from_grid_kwh * journal.consumption_price_low_eur_kwh
+
+        # Benefit is from discharging during high-price periods
         avoided_cost = Decimal(journal.battery_discharge_kwh or 0) * journal.consumption_price_high_eur_kwh
-        charge_cost = Decimal(journal.battery_charge_kwh or 0) * journal.consumption_price_low_eur_kwh
 
         monthly_savings = avoided_cost - charge_cost
         cumulative_savings += monthly_savings

--- a/tests/services/test_roi_calculations.py
+++ b/tests/services/test_roi_calculations.py
@@ -85,5 +85,49 @@ class TestNewROICalculations(unittest.TestCase):
         self.assertAlmostEqual(roi_status.method_1.cumulative_savings, 3.5, places=2)
         self.assertAlmostEqual(roi_status.method_1.remaining_balance, 5000 - 3.5, places=2)
 
+    @patch('app.services.roi_calculations.crud_battery')
+    def test_calculate_battery_roi_with_solar_charging(self, mock_crud_battery):
+        """
+        Tests that the battery ROI calculation correctly handles charging from solar.
+        """
+        mock_db = MagicMock()
+
+        # Mock Battery
+        mock_battery = Battery(
+            id=1,
+            purchase_date=date(2023, 1, 1),
+            purchase_cost_eur=Decimal('5000.00'),
+        )
+        mock_crud_battery.get.return_value = mock_battery
+
+        # Mock Journal with enough solar to cover battery charging
+        mock_journal = MonthlyJournal(
+            year=2023,
+            month=1,
+            solar_production_kwh=100.0,
+            grid_feed_in_low_kwh=0.0,
+            grid_feed_in_high_kwh=0.0,
+            grid_consumption_low_kwh=0.0,
+            grid_consumption_high_kwh=0.0,
+            battery_charge_kwh=50.0,
+            battery_discharge_kwh=45.0,
+            consumption_price_low_eur_kwh=Decimal('0.20'),
+            consumption_price_high_eur_kwh=Decimal('0.30'),
+            feed_in_tariff_low_eur_kwh=Decimal('0.05'),
+            feed_in_tariff_high_eur_kwh=Decimal('0.08'),
+        )
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_journal]
+
+        # Call function
+        roi_status = calculate_battery_roi(mock_db, 1)
+
+        # Assertions
+        # Avoided cost = 45 * 0.30 = 13.5
+        # Charge cost should be 0, as charging is covered by solar
+        # Monthly savings = 13.5 - 0 = 13.5
+        self.assertAlmostEqual(roi_status.method_1.cumulative_savings, 13.5, places=2)
+        self.assertAlmostEqual(roi_status.method_1.remaining_balance, 5000 - 13.5, places=2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The battery ROI calculation incorrectly assumed all charging was from the grid at a low-tariff price. This resulted in an inaccurate ROI that was always lower than reality when solar charging occurred.

This commit refactors the `calculate_battery_roi` function to:
1.  Calculate the available self-consumed solar energy.
2.  Prioritize this free solar energy for battery charging.
3.  Only apply a cost to the portion of the charge that must have come from the grid.

A new test case has been added to verify that the ROI is calculated correctly in a scenario with solar charging, ensuring the bug is fixed and preventing future regressions.