### PR TITLE
fix(frontend): Add missing Feather Icons library

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JouleJournal - Admin Dashboard</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/feather-icons/4.29.2/feather.min.js"></script>
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/admin.css">
     <link rel="stylesheet" href="/static/css/theme.css">


### PR DESCRIPTION
The admin panel buttons were not working because the Feather Icons library was missing. The `admin.js` script was referencing the `feather` object, which was not defined. This caused a `ReferenceError` that prevented the rest of the script from executing, including the event listeners for the buttons.

This commit adds the Feather Icons library via a CDN script tag to `templates/admin.html`. This makes the `feather` object available to the `admin.js` script and allows it to execute correctly, fixing the broken buttons.