### PR TITLE
feat: Adjust mock data generation to 24 months

### DIFF
--- a/app/api/endpoints/debug.py
+++ b/app/api/endpoints/debug.py
@@ -32,7 +32,7 @@ def fill_database(
     db: Session = Depends(deps.get_db)
 ):
     """
-    Fill the database with mockup data for 2.5 years.
+    Fill the database with mockup data for 2 years.
     """
     try:
         crud_debug.fill_database_with_mock_data(db)

--- a/app/crud/crud_debug.py
+++ b/app/crud/crud_debug.py
@@ -8,7 +8,7 @@ fake = Faker()
 
 def fill_database_with_mock_data(db: Session):
     """
-    Fill the database with mockup data for the last 2.5 years.
+    Fill the database with mockup data for the last 2 years.
     """
     # Create one-time installations
     solar_panel = models.SolarPanel(
@@ -47,8 +47,8 @@ def fill_database_with_mock_data(db: Session):
         )
         db.add(tariff)
 
-    # Create monthly journal entries for the last 30 months
-    for i in range(30):
+    # Create monthly journal entries for the last 24 months
+    for i in range(24):
         month_date = today - timedelta(days=i * 30)
         journal_entry = models.MonthlyJournal(
             year=month_date.year,


### PR DESCRIPTION
The `add_fill_database_with_mockup_data` command now generates data for the 24 most recent months, instead of 30.

This change modifies the loop in `app/crud/crud_debug.py` to iterate 24 times. The docstrings in both `app/crud/crud_debug.py` and `app/api/endpoints/debug.py` have been updated to reflect this change.