### PR TITLE
fix: Display last 24 months of journal data

### DIFF
--- a/app/api/endpoints/debug.py
+++ b/app/api/endpoints/debug.py
@@ -32,7 +32,7 @@ def fill_database(
     db: Session = Depends(deps.get_db)
 ):
     """
-    Fill the database with mockup data for 2.5 years.
+    Fill the database with mockup data for 2 years.
     """
     try:
         crud_debug.fill_database_with_mock_data(db)

--- a/app/api/endpoints/journal.py
+++ b/app/api/endpoints/journal.py
@@ -9,18 +9,17 @@ from app.crud import crud_journal
 
 router = APIRouter()
 
-@router.get("/{year}", response_model=List[journal_schema.MonthlyJournal])
-def read_journals_for_year(
-    year: int,
+@router.get("/", response_model=List[journal_schema.MonthlyJournal])
+def read_journals(
     db: Session = Depends(get_db),
     current_user: str = Depends(deps.get_current_user)
 ):
     """
-    Retrieve all monthly journal entries for a specific year.
-    If a journal for a month doesn't exist, it will be created.
+    Retrieve the last 24 monthly journal entries, sorted chronologically.
     """
-    journals = crud_journal.get_or_create_journals_for_year(db, year=year)
-    return journals
+    journals = crud_journal.get_journals(db, limit=24)
+    # Reverse the list to have the oldest month first
+    return journals[::-1]
 
 @router.put("/{year}/{month}", response_model=journal_schema.MonthlyJournal)
 def update_monthly_journal(

--- a/app/crud/crud_debug.py
+++ b/app/crud/crud_debug.py
@@ -8,7 +8,7 @@ fake = Faker()
 
 def fill_database_with_mock_data(db: Session):
     """
-    Fill the database with mockup data for the last 2.5 years.
+    Fill the database with mockup data for the last 2 years.
     """
     # Create one-time installations
     solar_panel = models.SolarPanel(
@@ -47,12 +47,19 @@ def fill_database_with_mock_data(db: Session):
         )
         db.add(tariff)
 
-    # Create monthly journal entries for the last 30 months
-    for i in range(30):
-        month_date = today - timedelta(days=i * 30)
+    # Create monthly journal entries for the last 24 months
+    current_year = today.year
+    current_month = today.month
+    for i in range(24):
+        year = current_year
+        month = current_month - i
+        while month <= 0:
+            month += 12
+            year -= 1
+
         journal_entry = models.MonthlyJournal(
-            year=month_date.year,
-            month=month_date.month,
+            year=year,
+            month=month,
             grid_consumption_low_kwh=random.uniform(100, 300),
             grid_consumption_high_kwh=random.uniform(50, 200),
             grid_feed_in_low_kwh=random.uniform(20, 100),

--- a/app/crud/crud_journal.py
+++ b/app/crud/crud_journal.py
@@ -49,21 +49,6 @@ def remove_journal(db: Session, *, journal_id: int) -> Optional[models.MonthlyJo
     return db_obj
 
 
-def get_or_create_journals_for_year(db: Session, *, year: int) -> List[models.MonthlyJournal]:
-    """
-    Retrieves all 12 monthly journals for a given year.
-    If a journal for a specific month does not exist, it creates an empty one.
-    """
-    journals = []
-    for month in range(1, 13):
-        journal = get_journal_by_year_and_month(db, year=year, month=month)
-        if not journal:
-            journal_in = journal_schema.MonthlyJournalCreate(year=year, month=month)
-            journal = create_journal(db=db, obj_in=journal_in)
-        journals.append(journal)
-    # Sort journals by month
-    journals.sort(key=lambda j: j.month)
-    return journals
 
 
 def update_journal(db: Session, *, year: int, month: int, obj_in: journal_schema.MonthlyJournalBase) -> Optional[models.MonthlyJournal]:


### PR DESCRIPTION
This commit addresses the issue where the application was not displaying the last 24 months of mock data.

The fix includes:
1.  Correcting the mock data generation logic in `app/crud/crud_debug.py` to accurately calculate the last 24 months relative to the current date.
2.  Modifying the journal API endpoint in `app/api/endpoints/journal.py`. The endpoint now returns the 24 most recent journal entries, sorted chronologically, instead of all entries for a specific year.
3.  Removing the unused `get_or_create_journals_for_year` function.

This ensures that the backend provides the necessary data for the frontend to display the desired 24-month period. The frontend will need to be updated to use the new `GET /api/journal/` endpoint.