### PR TITLE
fix: Correct mock data generation to 24 months

### DIFF
--- a/app/api/endpoints/debug.py
+++ b/app/api/endpoints/debug.py
@@ -32,7 +32,7 @@ def fill_database(
     db: Session = Depends(deps.get_db)
 ):
     """
-    Fill the database with mockup data for 2.5 years.
+    Fill the database with mockup data for 2 years.
     """
     try:
         crud_debug.fill_database_with_mock_data(db)

--- a/app/crud/crud_debug.py
+++ b/app/crud/crud_debug.py
@@ -8,7 +8,7 @@ fake = Faker()
 
 def fill_database_with_mock_data(db: Session):
     """
-    Fill the database with mockup data for the last 2.5 years.
+    Fill the database with mockup data for the last 2 years.
     """
     # Create one-time installations
     solar_panel = models.SolarPanel(
@@ -47,12 +47,19 @@ def fill_database_with_mock_data(db: Session):
         )
         db.add(tariff)
 
-    # Create monthly journal entries for the last 30 months
-    for i in range(30):
-        month_date = today - timedelta(days=i * 30)
+    # Create monthly journal entries for the last 24 months
+    current_year = today.year
+    current_month = today.month
+    for i in range(24):
+        year = current_year
+        month = current_month - i
+        while month <= 0:
+            month += 12
+            year -= 1
+
         journal_entry = models.MonthlyJournal(
-            year=month_date.year,
-            month=month_date.month,
+            year=year,
+            month=month,
             grid_consumption_low_kwh=random.uniform(100, 300),
             grid_consumption_high_kwh=random.uniform(50, 200),
             grid_feed_in_low_kwh=random.uniform(20, 100),


### PR DESCRIPTION
This commit corrects the logic for the `fill_database_with_mockup_data` command. The implementation now correctly generates journal entries for the 24 most recent months relative to the current date.

This change is limited to the data generation script in `app/crud/crud_debug.py` and its related docstrings, as per the user's final request. All other parts of the application have been verified to be in their original, working state, resolving previous issues where the API was unintentionally modified.