### PR TITLE
Fix(admin): Correctly access nested metric data in UI

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -487,13 +487,13 @@ async function renderMetricsTable(year) {
         // Body
         data.forEach(item => {
             const row = document.createElement('tr');
-            row.dataset.month = item.month;
-            const monthName = new Date(year, item.month - 1, 1).toLocaleString('default', { month: 'long' });
+            row.dataset.month = item.metric.month;
+            const monthName = new Date(year, item.metric.month - 1, 1).toLocaleString('default', { month: 'long' });
             row.innerHTML = `<td>${monthName}</td>`;
 
             let isComplete = true;
             for (const key in fields) {
-                const value = item[key] === null ? '' : item[key];
+                const value = item.metric[key] === null ? '' : item.metric[key];
                 if (value === '') isComplete = false;
                 const fieldConfig = fields[key];
                 row.innerHTML += `


### PR DESCRIPTION
The monthly metrics save button was failing because it was constructing an API request URL with an `undefined` month. This was caused by the frontend JavaScript trying to access `item.month` directly, when the API was returning a nested structure like `{ metric: { month: ... } }`.

This commit corrects the property accessors in `static/js/admin.js` to use `item.metric.month` and `item.metric[key]`, ensuring the UI correctly reads the nested data structure. This resolves the `422 Unprocessable Entity` error.