### PR TITLE
Fix Docker build by updating poetry install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY pyproject.toml poetry.lock* /app/
 # Install project dependencies
 # Using --no-lock to resolve dependencies from pyproject.toml, which is safer across different environments
 # Using --no-root because we only need the dependencies, not the project itself installed.
-RUN poetry install --no-root --no-dev --no-lock
+RUN poetry install --no-root --without dev
 
 # Copy the rest of the application code into the container
 COPY ./app /app/app


### PR DESCRIPTION
The `poetry install` command in the `Dockerfile` was using the deprecated `--no-dev` flag, which is not available in the version of poetry being used (2.1.3).

This change replaces the `--no-dev` flag with the correct `--without dev` flag to exclude development dependencies during the Docker build. The `--no-lock` flag was also removed to ensure reproducible builds by using the `poetry.lock` file.