### PR TITLE
Fix alembic ModuleNotFoundError and poetry deprecation warning

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -8,7 +8,7 @@ from sqlalchemy import pool
 from alembic import context
 
 # Make sure the app directory is in the path, so we can import from app
-sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.db.session import Base
 # Import all models here so that Base has them registered for autogenerate

--- a/poetry.lock
+++ b/poetry.lock
@@ -1617,4 +1617,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "c08f7ec23545100f77d9b240ef4482066329743b34bca385bbb012a009fcd517"
+content-hash = "095cdaad6b05747837b8b4aa17fb35a6b613ad70f32619f95c5b7324a99bde17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ passlib = {extras = ["bcrypt"], version = "*"}
 alembic = "*"
 python-multipart = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
 httpx = "*"
 pytest-env = "*"


### PR DESCRIPTION
- Updated `pyproject.toml` to use `[tool.poetry.group.dev.dependencies]` instead of the deprecated `[tool.poetry.dev-dependencies]`.
- Updated `alembic/env.py` to use `os.path.abspath` to ensure the project root is correctly added to the `PYTHONPATH`. This resolves the `ModuleNotFoundError` when running `alembic` from the command line.