### PR TITLE
Fix ModuleNotFoundError when running alembic migrations.

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -8,7 +9,7 @@ from sqlalchemy import pool
 from alembic import context
 
 # Make sure the app directory is in the path, so we can import from app
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.db.session import Base
 # Import all models here so that Base has them registered for autogenerate


### PR DESCRIPTION
The alembic environment script `alembic/env.py` was unable to import the `app` module because the project root was not correctly added to the `sys.path`.

This change replaces the `os.path` manipulation with a more robust `pathlib` based solution to ensure the project root is always in the python path when running migrations.