### PR TITLE
Fix ModuleNotFoundError when running alembic commands.

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,7 +9,7 @@ from sqlalchemy import pool
 from alembic import context
 
 # Make sure the app directory is in the path, so we can import from app
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.db.session import Base
 # Import all models here so that Base has them registered for autogenerate


### PR DESCRIPTION
When running `alembic upgrade head` or other alembic commands, a `ModuleNotFoundError: No module named 'app.db'` would occur.

This was caused by a redundant `sys.path` manipulation in `alembic/env.py`. The `alembic.ini` file is already configured with `prepend_sys_path = .`, which adds the project root to Python's path. The additional, manual path insertion in `env.py` was conflicting with this, leading to the import error.

By removing the redundant code from `alembic/env.py`, we rely on the standard and correct configuration from `alembic.ini`, which resolves the issue.