### PR TITLE
feat: Configure Docker to use PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,22 @@
 version: '3.8'
 
 services:
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-joulejournal}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
+      - POSTGRES_DB=${POSTGRES_DB:-joulejournal}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-joulejournal} -d ${POSTGRES_DB:-joulejournal}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   backend:
     build:
       context: .
@@ -8,11 +24,14 @@ services:
         - PORT=${PORT:-5201}
     ports:
       - "${PORT:-5201}:${PORT:-5201}"
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       - PORT=${PORT:-5201}
       - ADMIN_USER=${ADMIN_USER}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - DATABASE_URL=sqlite:///joulejournal.db
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joulejournal}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-joulejournal}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - BACKEND_CORS_ORIGINS=http://localhost:${PORT:-5201},http://127.0.0.1:${PORT:-5201},http://192.168.0.178:${PORT:-5201}
     command: >
@@ -26,3 +45,6 @@ services:
         uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-5201}
       "
     restart: always
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
This commit updates the Docker Compose configuration to use a PostgreSQL database service instead of SQLite for local development.

- Adds a `db` service for PostgreSQL 15.
- Adds a volume for persistent database storage.
- Updates the `backend` service to depend on the `db` service.
- Configures the `DATABASE_URL` to connect to the PostgreSQL service.
- Adds a healthcheck to the `db` service to ensure the backend starts only when the database is ready.