### PR TITLE
fix(js): Prevent sending null for required fields

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -357,9 +357,12 @@ async function handleFormSubmit(event) {
 
     const formData = new FormData(form);
     const data = Object.fromEntries(formData.entries());
+    const config = MODEL_CONFIG[modelName].fields;
 
+    // Only set non-required fields to null if they are empty.
+    // Let the backend handle validation for required fields.
     for (const key in data) {
-        if (data[key] === '') {
+        if (data[key] === '' && config[key] && !config[key].required) {
             data[key] = null;
         }
     }


### PR DESCRIPTION
The 'Add Solar Panel' and 'Add Battery' forms were failing with a 400 Bad Request error.

This was caused by the javascript converting all empty form fields to 'null' before sending the request to the API.

The backend API does not accept 'null' for required fields, leading to the error.

This commit updates the form handling logic in 'static/js/admin.js' to only convert empty non-required fields to 'null'. Required fields that are empty will be sent as empty strings, allowing the backend to perform proper validation and return a more informative error message.