### PR TITLE
Fix(battery): Make brand optional in CRUD operation

### DIFF
--- a/app/crud/crud_battery.py
+++ b/app/crud/crud_battery.py
@@ -27,7 +27,7 @@ def create(db: Session, *, obj_in: BatteryCreate) -> models.Battery:
         name=obj_in.name,
         purchase_date=obj_in.purchase_date,
         purchase_cost_eur=obj_in.purchase_cost_eur,
-        brand=obj_in.brand,
+        brand=getattr(obj_in, 'brand', None),
         capacity_kwh=obj_in.capacity_kwh
     )
     db.add(db_obj)

--- a/tests/test_api_batteries.py
+++ b/tests/test_api_batteries.py
@@ -47,6 +47,13 @@ def test_create_battery(db_session):
     assert data["name"] == "Test Battery"
     assert data["brand"] == "TestBrand"
 
+def test_create_battery_without_brand(db_session):
+    response = client.post("/api/batteries/", json={"name": "Test Battery No Brand", "purchase_date": "2023-01-01", "purchase_cost_eur": 3000, "capacity_kwh": 10.0})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Test Battery No Brand"
+    assert data["brand"] is None
+
 def test_read_batteries(db_session):
     client.post("/api/batteries/", json={"name": "Test Battery 1", "purchase_date": "2023-01-01", "purchase_cost_eur": 3000, "capacity_kwh": 10.0})
     client.post("/api/batteries/", json={"name": "Test Battery 2", "purchase_date": "2023-01-02", "purchase_cost_eur": 3500, "capacity_kwh": 12.0})


### PR DESCRIPTION
The 'add battery' functionality was failing because the CRUD function was attempting to access the 'brand' attribute directly, causing an error if it wasn't provided in the payload.

This commit updates the `create` function in `app/crud/crud_battery.py` to safely handle the optional `brand` attribute by using `getattr`.

Additionally, a new test case has been added to `tests/test_api_batteries.py` to verify that a battery can be successfully created without a `brand`.