### PR TITLE
Fix backend startup without optional dependencies

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,28 +1,102 @@
+from __future__ import annotations
+
+import os
 from functools import lru_cache
-from typing import List
+from pathlib import Path
+from typing import Dict, Iterable, List
 
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", case_sensitive=True, extra="ignore")
+def _parse_env_file(path: Path) -> Dict[str, str]:
+    """Parse a minimal subset of .env files.
+
+    The project previously relied on ``pydantic-settings`` to read configuration
+    from environment variables and an optional ``.env`` file. In offline
+    environments this extra dependency was missing, which prevented the
+    application from starting. To keep the behaviour familiar we read the file
+    ourselves, supporting ``KEY=VALUE`` pairs and ignoring blank lines or
+    comments.
+    """
+
+    if not path.exists():
+        return {}
+
+    values: Dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _merge_env_vars(env_file_values: Dict[str, str], process_env: Iterable[tuple[str, str]]) -> Dict[str, str]:
+    merged = dict(env_file_values)
+    for key, value in process_env:
+        merged[key] = value
+    return merged
+
+
+class Settings(BaseModel):
+    model_config = ConfigDict(frozen=True)
 
     project_name: str = "JouleJournal"
     api_v1_prefix: str = "/api"
-    secret_key: str = Field("CHANGEME_SUPER_SECRET_KEY", alias="SECRET_KEY")
+    secret_key: str = "CHANGEME_SUPER_SECRET_KEY"
     algorithm: str = "HS256"
-    access_token_expires_minutes: int = Field(60 * 24, alias="ACCESS_TOKEN_EXPIRES_MINUTES")
-    database_url: str = Field("sqlite:///./joulejournal.db", alias="DATABASE_URL")
-    first_superuser_email: str = Field("admin@joulejournal.local", alias="FIRST_SUPERUSER_EMAIL")
-    first_superuser_password: str = Field("ChangeMe123!", alias="FIRST_SUPERUSER_PASSWORD")
+    access_token_expires_minutes: int = 60 * 24
+    database_url: str = "sqlite:///./joulejournal.db"
+    first_superuser_email: str = "admin@joulejournal.local"
+    first_superuser_password: str = "ChangeMe123!"
     backend_cors_origins: List[str] = Field(default_factory=list)
-    debug: bool = Field(False, alias="DEBUG")
+    debug: bool = False
+
+    @classmethod
+    def load(cls, env_file: str = ".env") -> "Settings":
+        backend_dir = Path(__file__).resolve().parent.parent.parent
+        env_path = (backend_dir / env_file).resolve()
+
+        env_values = _merge_env_vars(
+            _parse_env_file(env_path),
+            os.environ.items(),
+        )
+
+        data: Dict[str, object] = {}
+        field_to_env = {
+            "project_name": "PROJECT_NAME",
+            "api_v1_prefix": "API_V1_PREFIX",
+            "secret_key": "SECRET_KEY",
+            "algorithm": "ALGORITHM",
+            "access_token_expires_minutes": "ACCESS_TOKEN_EXPIRES_MINUTES",
+            "database_url": "DATABASE_URL",
+            "first_superuser_email": "FIRST_SUPERUSER_EMAIL",
+            "first_superuser_password": "FIRST_SUPERUSER_PASSWORD",
+            "backend_cors_origins": "BACKEND_CORS_ORIGINS",
+            "debug": "DEBUG",
+        }
+
+        for field_name, env_key in field_to_env.items():
+            if env_key in env_values:
+                data[field_name] = env_values[env_key]
+
+        origins = data.get("backend_cors_origins")
+        if isinstance(origins, str):
+            data["backend_cors_origins"] = [
+                origin.strip()
+                for origin in origins.split(",")
+                if origin.strip()
+            ]
+
+        return cls(**data)
 
 
 @lru_cache()
 def get_settings() -> Settings:
-    return Settings()
+    return Settings.load()
 
 
 settings = get_settings()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,20 +1,55 @@
+import base64
+import binascii
+import hashlib
+import hmac
+import secrets
 from datetime import datetime, timedelta
 from typing import Optional
 
 from jose import jwt
-from passlib.context import CryptContext
 
 from .config import settings
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+_PASSWORD_ALGORITHM = "pbkdf2_sha256"
+_PBKDF2_ITERATIONS = 390_000
+_SALT_BYTES = 16
+
+
+def _pbkdf2(password: str, salt: bytes, iterations: int) -> bytes:
+    return hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    try:
+        algorithm, iter_str, b64_salt, b64_hash = hashed_password.split("$", 3)
+        iterations = int(iter_str)
+    except (ValueError, TypeError):
+        return False
+
+    if algorithm != _PASSWORD_ALGORITHM:
+        return False
+
+    try:
+        salt = base64.b64decode(b64_salt)
+        expected_hash = base64.b64decode(b64_hash)
+    except (binascii.Error, ValueError):
+        return False
+
+    new_hash = _pbkdf2(plain_password, salt, iterations)
+    return hmac.compare_digest(new_hash, expected_hash)
 
 
 def get_password_hash(password: str) -> str:
-    return pwd_context.hash(password)
+    salt = secrets.token_bytes(_SALT_BYTES)
+    derived = _pbkdf2(password, salt, _PBKDF2_ITERATIONS)
+    return "$".join(
+        (
+            _PASSWORD_ALGORITHM,
+            str(_PBKDF2_ITERATIONS),
+            base64.b64encode(salt).decode("ascii"),
+            base64.b64encode(derived).decode("ascii"),
+        )
+    )
 
 
 def create_access_token(subject: str, expires_minutes: Optional[int] = None) -> str:

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,11 +1,21 @@
+import re
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class UserBase(BaseModel):
-    email: EmailStr
+    email: str
     full_name: Optional[str] = None
+
+    _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        if not cls._EMAIL_PATTERN.fullmatch(value):
+            raise ValueError("Invalid email address format")
+        return value
 
 
 class UserCreate(UserBase):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,9 +3,7 @@ uvicorn[standard]==0.23.2
 SQLAlchemy==2.0.21
 psycopg2-binary==2.9.9
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
 Jinja2==3.1.2
 alembic==1.12.0
 pydantic==2.7.4
-pydantic-settings==2.3.3


### PR DESCRIPTION
## Summary
- reimplement the settings loader to read environment variables without relying on `pydantic-settings`
- replace the passlib bcrypt context with a PBKDF2-based password hasher that requires no external wheels
- add a lightweight email validator so user schemas no longer depend on `email-validator`
- update backend requirements to reflect the trimmed dependency list

## Testing
- uvicorn app.main:app --reload

------
https://chatgpt.com/codex/tasks/task_e_68fa71f592d88333b18e8322fd572d9b